### PR TITLE
Reorganized repo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,10 @@
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
+title: The F# Mirror
+baseurl: ""
+url: "https://the-fsharp-mirror.github.io"
+permalink: :year/:title
 
 # Build settings
 markdown: kramdown

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
   <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet"   
     integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
   <link href="https://fonts.googleapis.com/css?family=PT+Sans|PT+Serif+Caption" rel="stylesheet">
-  <title>The F# Mirror</title>
+  <title>{{ site.title | escape }}{% if page.title %} &lt;| {{ page.title | escape }}{% endif %}</title>
   <style type="text/css">
   body {
     font-family:'PT Sans';
@@ -41,6 +41,10 @@
     font:16pt 'PT Sans';
     margin:10px 0px 30px 0px;
   }
+  hr.older {
+    border:solid 2px black;
+    margin: 0 -10px;
+  }
   </style>
 </head>
 <body>
@@ -48,7 +52,7 @@
     <div class="row">
       <div class="col-md-1"></div>
       <div class="col-sm-12 col-md-10 header">
-        <h1>The F# Mirror</h1>
+        <h1>{{ site.title }}</h1>
       </div>
     </div>
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+<h1>{{ page.title | smartify }}</h1>
+<h4>{{ page.author | smartify }}, {{ page.date | date: "%-d %B %Y" }}</h4>
+{{ content | smartify }}

--- a/_posts/2017/2017-07-06-board-member-plans-for-the-first-two-months.md
+++ b/_posts/2017/2017-07-06-board-member-plans-for-the-first-two-months.md
@@ -1,11 +1,9 @@
 ---
-layout: page
-title: The F# Mirror
+layout: post
+title: Board member plans for the first two months
+author: Tomas Petricek
+date: 2017-07-06
 ---
-
-# Board member plans for the first two months
-
-#### Tomas Petricek, 6 July 2017
 
 Back in May 2017, the F# Software Foundation [elected the new Board of 
 Trustees](http://foundation.fsharp.org/2017_annual_members_meeting). In the previous years,

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ layout: default
   {% endif %}
 {% endfor %}
 
-{% if site.posts | size > 3 %}
+{% if site.posts.size > 3 %}
   <hr class="older">
   <h2>Past Reflections</h2>
   {% for post in site.posts offset:3 %}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+---
+layout: default
+---
+{% for post in site.posts limit:3 %}
+  <h1>{{ post.title | smartify }}</h1>
+  <h4>
+    {{ post.author | smartify }}, {{ post.date | date: "%-d %B %Y" }}
+    <a href="{{ post.url | absolute_url }}">#</a>
+  </h4>
+  {{ post.content | smartify }}
+  {% if post.previous %}
+    <br><br>
+  {% endif %}
+{% endfor %}
+
+{% if site.posts | size > 3 %}
+  <hr class="older">
+  <h2>Past Reflections</h2>
+  {% for post in site.posts offset:3 %}
+    <strong><a href="{{ post.url | absolute_url }}">{{ post.title | smartify }}</a></strong>
+    by {{ post.author | smartify }} <em>({{ post.date | date: "%-d %B %Y" }})</em><br>
+  {% endfor %}
+{% endif %}


### PR DESCRIPTION
- Moved index to _posts
- Renamed page layout to default, use default layout for index and post templates
- Created index template with most 3 recent posts displayed, and earlier ones linked at the bottom of the page

I also put the year in both the `_posts` directory tree and the permalink structure.  The two aren't required to be in sync, but I've found that it's a good way to keep the posts manageable, especially the longer it's used.

Here's a screenshot with 4 "older" posts that I put in for testing the template. (those didn't get committed)
![with-older-posts](https://user-images.githubusercontent.com/880348/28251389-c2636756-6a41-11e7-9a37-2df4afe10540.png)
